### PR TITLE
Change text selector to config_entry for timer fields

### DIFF
--- a/custom_components/simple_timer/services.yaml
+++ b/custom_components/simple_timer/services.yaml
@@ -8,7 +8,8 @@ start_timer:
       description: The config entry ID of the simple timer sensor.
       required: true
       selector:
-        text:
+        config_entry:
+          integration: simple_timer
     duration:
       name: Duration
       description: The duration of the timer in minutes.
@@ -35,7 +36,8 @@ add_timer:
       description: The config entry ID of the simple timer sensor.
       required: true
       selector:
-        text:
+        config_entry:
+          integration: simple_timer
     duration:
       name: Duration
       description: The duration to add in minutes.
@@ -75,7 +77,8 @@ cancel_timer:
       description: The config entry ID of the simple timer sensor.
       required: true
       selector:
-        text:
+        config_entry:
+          integration: simple_timer
     turn_off_entity:
       name: Turn Off Entity
       description: If true, turns off the associated switch entity when cancelling.
@@ -93,7 +96,8 @@ update_switch_entity:
       description: The config entry ID of the simple timer sensor.
       required: true
       selector:
-        text:
+        config_entry:
+          integration: simple_timer
     switch_entity_id:
       name: Switch Entity
       description: The entity ID of the switch to monitor (e.g., switch.my_timer).
@@ -111,7 +115,8 @@ force_name_sync:
       description: The config entry ID to sync. If omitted, syncs all Simple Timer sensors.
       required: false
       selector:
-        text:
+        config_entry:
+          integration: simple_timer
 
 manual_power_toggle:
   name: Manual Power Toggle
@@ -122,7 +127,8 @@ manual_power_toggle:
       description: The config entry ID of the simple timer sensor.
       required: true
       selector:
-        text:
+        config_entry:
+          integration: simple_timer
     action:
       name: Action
       description: The action to perform (turn_on or turn_off).
@@ -142,7 +148,8 @@ reset_daily_usage:
       description: The config entry ID of the simple timer sensor
       required: true
       selector:
-        text:
+        config_entry:
+          integration: simple_timer
 
 test_notification:
   name: Test Notification
@@ -153,7 +160,8 @@ test_notification:
       description: The config entry ID of the simple timer sensor
       required: true
       selector:
-        text:
+        config_entry:
+          integration: simple_timer
     message:
       name: Message
       description: Test message to send
@@ -161,7 +169,7 @@ test_notification:
       default: "Test notification"
       selector:
         text:
-        
+
 reload_resources:
   name: Reload Frontend Resources
   description: Manually reload and update the Simple Timer card frontend resources with the current version


### PR DESCRIPTION
Utilize selectors so we don't have to hunt for values.